### PR TITLE
Fixed a couple of issues with they way matchers affect context.

### DIFF
--- a/jasmine.io
+++ b/jasmine.io
@@ -140,7 +140,7 @@ expect := method(actual,
     matcher actual := actual
     matcher expected := call message arguments at(0)
     matcher expectation := call message name
-    matcher success := matcher doMessage(call message, actual)
+    matcher success := call delegateTo(matcher)
 
     if(inverted, matcher success := if(matcher success, false, true))
     if(matcher success == false, Exception raise(matcher message(inverted)))

--- a/matcher_spec.io
+++ b/matcher_spec.io
@@ -66,7 +66,6 @@ describe("toThrow matcher",
 		matcher := expect(block(MyException raise)) toThrow(MyException)
 		expect(matcher success) toBe(true)
 	)
-
 )
 
 describe("Matcher tests for toEqual",
@@ -203,5 +202,18 @@ describe("Not matcher",
 	it("inverts default error messages",
 		ex := try(expect(1) not toBeLessThan(2))
 		expect(ex error) toEqual("Expected 1 not to be less than 2")
+	)
+)
+
+describe("Context handling in matchers",
+	it("should evaluate the argument in its existing locals context",
+		x := 2
+		expect(2) toBe(x) 
+	),
+
+	it("should not alter the spec's locals context",
+		x := 2
+		expect(true) toEqual(true)
+		expect(x) toBe(2)
 	)
 )


### PR DESCRIPTION
- Arguments to matchers were evaluated in the matcher's context
  rather than the caller's, which broke arguments that weren't
  literals.
- Matchers could change their caller's locals context if the
  return value wasn't captured.
