### PR TITLE
Fixed issue #12, 'Error executing specs with nill beforeEach/afterEach'

### DIFF
--- a/jasmine.io
+++ b/jasmine.io
@@ -243,9 +243,9 @@ Suite beforeEach := method()
 Suite afterEach := method()
 Suite run := method(
   specs foreach(spec,    
-    doMessage(beforeEach)
+    (beforeEach != nil) ifTrue (doMessage(beforeEach))
     spec run
-    doMessage(afterEach)
+    (afterEach != nil) ifTrue (doMessage(afterEach))
   )
 )
 


### PR DESCRIPTION
Closed #12 by checking beforeEach/afterEach for nil before using as parameter in doMessage.
